### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ export class MonthSelectorCalendar extends Component {
     monthTapped: PropTypes.func,
     monthDisabledStyle: PropTypes.any,
     onYearChanged: PropTypes.func,
-    locale: PropTypes.object,
+    locale: PropTypes.string,
   }
 
   static defaultProps = {


### PR DESCRIPTION
To eliminate warning as locale in defaultProps is string type but propTypes for locale is object. Hence the warning